### PR TITLE
Replace charge_amps with charge_current_request

### DIFF
--- a/teslajsonpy/car.py
+++ b/teslajsonpy/car.py
@@ -885,7 +885,7 @@ class TeslaCar:
         """Send command to set charging amps."""
         # Only wake car if the value is different
         wake_if_asleep = value != self._vehicle_data.get("charge_state", {}).get(
-            "charge_amps"
+            "charge_current_request"
         )
         data = await self._send_command(
             "CHARGING_AMPS", charging_amps=int(value), wake_if_asleep=wake_if_asleep
@@ -897,7 +897,7 @@ class TeslaCar:
             )
 
         if data and data["response"]["result"] is True:
-            params = {"charge_amps": int(value)}
+            params = {"charge_current_request": int(value)}
             self._vehicle_data["charge_state"].update(params)
 
     async def set_cabin_overheat_protection(self, option: str) -> None:


### PR DESCRIPTION
When calling `set_charging_amps` it looks for a parameter `charge_amps` and uses this to save the updated value, however this parameter isnt used anywhere else. I believe this is actually meant to be the `charge_current_request` parameter.

Fixes https://github.com/alandtse/tesla/issues/479